### PR TITLE
Use relative path for the demo's script src

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   
   <body>
     <div id ='display'></div>
-    <script src = '/home/lee/Desktop/table-sort-js/public/table-sort.js'></script> 
+    <script src="table-sort.js"></script>
 
     <h1>Testing table sort js</h1>
     <table class="table-sort table-arrows">


### PR DESCRIPTION
Currently the src of the script in the demo is a hard coded path. This path doesn't work on my computer. This change allows me to run the demo without any errors.