### PR TITLE
Set thead's cursor styling instantly

### DIFF
--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -33,19 +33,7 @@ function tableSortJs() {
             const tableBody = sortableTable.querySelector("tbody");
             const tableHeadHeaders = tableHead.querySelectorAll("th");
 
-
-            // Display a mouse pointer on hover over table headers.
-            tableHead.addEventListener("mouseover", function (event) {
-                setCursor(tableHead, "pointer");
-            });
-            function setCursor(tag, cursorStyle) {
-                var elem;
-                if (sortableTable.getElementsByTagName && (elem = tag)) {
-                    if (elem.style) {
-                        elem.style.cursor = cursorStyle;
-                    }
-                }
-            }
+            tableHead.style.cursor = "pointer";
 
             for (let [columnIndex, th] of tableHeadHeaders.entries("table")) {
                 let timesClickedColumn = 0;


### PR DESCRIPTION
Currently we are waiting until we mouse over the table's head in order to set it's cursor style to pointer.
I was thinking we should just do it instantly.
This change also avoids needlessly setting the cursor style to pointer every time we mouse over the table's head.