### PR TITLE
Support display: none;

### DIFF
--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -328,21 +328,22 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
 
     th.addEventListener("click", function () {
       const columnData = [];
-      const tableRows = Array.prototype.filter.call(tableBody.querySelectorAll("tr"), e => {
-        return e.style.display != 'none';
+      // To make it work even if there is a tr with display: none; in the table, only the tr that is currently displayed is subject to sorting.
+      const visibleTableRows = Array.prototype.filter.call(tableBody.querySelectorAll("tr"), tr => {
+        return tr.style.display !== 'none';
       });
 
       let isDataAttribute = th.classList.contains("data-sort");
       // Check if using data-sort attribute; if so sort by value of data-sort
       // attribute.
       if (isDataAttribute) {
-        sortDataAttributes(tableRows, columnData);
+        sortDataAttributes(visibleTableRows, columnData);
       }
 
       let isFileSize = th.classList.contains("file-size");
       // Handle filesize sorting (e.g KB, MB, GB, TB) - Turns data into KiB.
       if (isFileSize) {
-        sortFileSize(tableRows, columnData);
+        sortFileSize(visibleTableRows, columnData);
       }
 
       // Checking if user has clicked different column from the first column if
@@ -354,8 +355,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
 
       timesClickedColumn += 1;
 
-      getTableData(tableRows, columnData, isFileSize, isDataAttribute);
-      updateTable(tableRows, columnData, isFileSize);
+      getTableData(visibleTableRows, columnData, isFileSize, isDataAttribute);
+      updateTable(visibleTableRows, columnData, isFileSize);
     });
   }
 }

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -328,7 +328,9 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
 
     th.addEventListener("click", function () {
       const columnData = [];
-      const tableRows = tableBody.querySelectorAll("tr");
+      const tableRows = Array.prototype.filter.call(tableBody.querySelectorAll("tr"), e => {
+        return e.style.display != 'none';
+      });
 
       let isDataAttribute = th.classList.contains("data-sort");
       // Check if using data-sort attribute; if so sort by value of data-sort

--- a/test/table.js
+++ b/test/table.js
@@ -3,7 +3,7 @@ const { JSDOM } = jsdom;
 require("iconv-lite").encodingExists("foo");
 const tableSortJs = require("../public/table-sort");
 
-function createTestTable(testTableData, classTags="") {
+function createTestTable(testTableData, classTags="", invisibleIndex=[]) {
 
   let getClassTagsForTH = [];
   let testTableThRow = `<tr><th class="${classTags}">Testing Column</th></tr>`;
@@ -14,6 +14,8 @@ function createTestTable(testTableData, classTags="") {
     let testTableTdRow;
     if(classTags.includes("data-sort")){
       testTableTdRow = `<tr><td data-sort="${i}">${testTableData[i]}</td></tr>`;
+    }else if(invisibleIndex.includes(i)) {
+      testTableTdRow = `<tr style="display: none;"><td>${testTableData[i]}</td></tr>`;
     }else{
       testTableTdRow = `<tr><td>${testTableData[i]}</td></tr>`;
     }
@@ -46,7 +48,9 @@ function createTestTable(testTableData, classTags="") {
   const tableRows = tableBody.querySelectorAll("tr");
   const testIfSortedList = [];
   for (let [i, tr] of tableRows.entries()) {
-    testIfSortedList.push(tr.querySelectorAll("td").item(0).innerHTML);
+    if(tr.style.display !== 'none'){
+      testIfSortedList.push(tr.querySelectorAll("td").item(0).innerHTML);
+    }
   }
   return testIfSortedList;
 }

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -279,3 +279,23 @@ test("data-sort: example days of week  - reversed", () => {
         "Saturday",
   ]);
 });
+
+test("visible-tr-sort: example sort only visible trs", () => {
+  expect(
+    createTestTable(
+      [
+        "row1", // invisible
+        "row2",
+        "row3", // invisible
+        "row4",
+        "row5",
+      ],
+      "order-by-desc",
+      [0, 2]
+    )
+  ).toStrictEqual([
+        "row5",
+        "row4",
+        "row2",
+  ]);
+});


### PR DESCRIPTION
When implementing a feature that displays tr that matches the text entered by the user, it is likely that the implementation will simply hide tr that do not match by specifying display: none;.
However, the current table-sort.js does not work if a tr with display: none; is included in a table.
This problem can be easily fixed by simply fixing it to get tr that is not display: none.