### PR TITLE
Fixes issue with css removal when changing sort order.

### DIFF
--- a/npm/table-sort.js
+++ b/npm/table-sort.js
@@ -228,8 +228,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       }
 
       function clearArrows(arrowUp = "▲", arrowDown = "▼") {
-        th.innerText = th.innerText.replace(arrowUp, "");
-        th.innerText = th.innerText.replace(arrowDown, "");
+        th.innerHTML = th.innerHTML.replace(arrowUp, "");
+        th.innerHTML = th.innerHTML.replace(arrowDown, "");
       }
 
       if (columnData[0] === undefined) {

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -228,8 +228,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       }
 
       function clearArrows(arrowUp = "▲", arrowDown = "▼") {
-        th.innerText = th.innerText.replace(arrowUp, "");
-        th.innerText = th.innerText.replace(arrowDown, "");
+        th.innerHTML = th.innerHTML.replace(arrowUp, "");
+        th.innerHTML = th.innerHTML.replace(arrowDown, "");
       }
 
       if (columnData[0] === undefined) {


### PR DESCRIPTION
When css is used to display icons as headers previous version would remove inner html and replace it with blank or an arrow making use of SVG via CSS in table headers impossible.