### PR TITLE
fix(file-size): use exact multipliers for MiB, GiB, etc.

### DIFF
--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -93,11 +93,11 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       const unitType =
         /(\s?B|\s?KB|\s?KiB|\s?MB|\s?MiB|\s?GB|G\s?iB|\s?TB|\s?TiB)/i;
       const fileSizes = {
-        Kibibyte: 1024,
-        Mebibyte: 1.049e6,
-        Gibibyte: 1.074e9,
-        Tebibyte: 1.1e12,
-        Pebibyte: 1.126e15,
+        Kibibyte: 2 ** 10,
+        Mebibyte: 2 ** 20,
+        Gibibyte: 2 ** 30,
+        Tebibyte: 2 ** 40,
+        Pebibyte: 2 ** 50,
         Kilobyte: 1000,
         Megabyte: 1e6,
         Gigabyte: 1e9,
@@ -282,11 +282,11 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
             .querySelectorAll("td")
             .item(columnIndex).textContent;
           const fileSizes = {
-            Kibibyte: 1024,
-            Mebibyte: 1.049e6,
-            Gibibyte: 1.074e9,
-            Tebibyte: 1.1e12,
-            Pebibyte: 1.126e15,
+            Kibibyte: 2 ** 10,
+            Mebibyte: 2 ** 20,
+            Gibibyte: 2 ** 30,
+            Tebibyte: 2 ** 40,
+            Pebibyte: 2 ** 50,
           };
           // Remove the unique identifyer for duplicate values(#number).
           columnData[i] = columnData[i].replace(/#[0-9]*/, "");

--- a/test/order-by-desc.test.js
+++ b/test/order-by-desc.test.js
@@ -99,7 +99,7 @@ test("Order by file-size: file-size order-by-desc", () => {
       "10.00 GiB",
       "9.31 GiB",
       "10.00 MiB",
-      "9.53 MiB",
+      "9.54 MiB",
       "10.00 KiB",
       "9.77 KiB",
       "10.00 B",

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -95,7 +95,7 @@ test("Order by file-size: file-size", () => {
       "10.00 B",
       "9.77 KiB",
       "10.00 KiB",
-      "9.53 MiB",
+      "9.54 MiB",
       "10.00 MiB",
       "9.31 GiB",
       "10.00 GiB",


### PR DESCRIPTION
fix(file-size): use exact multipliers for MiB, GiB, etc.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/LeeWannacott/table-sort-js/pull/71).
* #74
* __->__ #71
