### PR TITLE
fix: handling negative and decimal numeric cases #63 and #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Refer to the documenation for examples on how to use table-sort-js with [HTML](h
 | "dates-ymd-sort"             | Sorts dates in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) yyyy/mm/dd format. e.g (2021/10/28). Use "/" or "-" as separator. |
 | "file-size-sort"             | Sorts file sizes(B->TiB) uses the binary prefix. (e.g 10 B, 100 KiB, 1 MiB); optional space between number and prefix.              |
 | "runtime-sort"               | Sorts runtime in hours minutes and seconds e.g (10h 1m 20s). Useful for sorting the GitHub actions Run time column...               |
+| "numeric-sort"               | Sorts numbers - Positive, Negative (Both minus and parenthesis representations), Decimals (can also be used for Semantic Versioning)|
 
 | &lt;th&gt; Classes that change defaults. | Description                                                                                                         |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Refer to the documenation for examples on how to use table-sort-js with [HTML](h
 | "dates-ymd-sort"             | Sorts dates in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) yyyy/mm/dd format. e.g (2021/10/28). Use "/" or "-" as separator. |
 | "file-size-sort"             | Sorts file sizes(B->TiB) uses the binary prefix. (e.g 10 B, 100 KiB, 1 MiB); optional space between number and prefix.              |
 | "runtime-sort"               | Sorts runtime in hours minutes and seconds e.g (10h 1m 20s). Useful for sorting the GitHub actions Run time column...               |
-| "numeric-sort"               | Sorts numbers - Positive, Negative (Both minus and parenthesis representations), Decimals (can also be used for Semantic Versioning)|
+| "numeric-sort"               | Sorts numbers - Positive, Negative (Both minus and parenthesis representations), and Decimals                                       |
 
 | &lt;th&gt; Classes that change defaults. | Description                                                                                                         |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -328,38 +328,39 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       const isPunctSort = th.classList.contains("punct-sort");
       const isAlphaSort = th.classList.contains("alpha-sort");
       const isNumericSort = th.classList.contains("numeric-sort");
+
+      function parseNumberFromString(str) {
+        let num;
+        str = str.slice(0, str.indexOf("#"));
+        if (str.match(/^\((\d+(?:\.\d+)?)\)$/)) {
+          num = -1 * Number(str.slice(1, -1));
+        } else {
+          num = Number(str);
+        }
+        return num;
+      }
+
+      function strLocaleCompare(str1, str2) {
+        return str1.localeCompare(
+          str2,
+          navigator.languages[0] || navigator.language,
+          { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
+        );
+      }
+
+      function handleNumbers(str1, str2) {
+        let num1, num2;
+        num1 = parseNumberFromString(str1);
+        num2 = parseNumberFromString(str2);
+
+        if (!isNaN(num1) && !isNaN(num2)) {
+          return num1 - num2;
+        } else {
+          return strLocaleCompare(str1, str2);
+        }
+      }
+
       function sortAscending(a, b) {
-        function parseNumberFromString(str) {
-          let num;
-          str = str.slice(0, str.indexOf("#"));
-          if (str.match(/^\((\d+(?:\.\d+)?)\)$/)) {
-            num = -1 * Number(str.slice(1, -1));
-          } else {
-            num = Number(str);
-          }
-          return num;
-        }
-
-        function strLocaleCompare(str1, str2) {
-          return str1.localeCompare(
-            str2,
-            navigator.languages[0] || navigator.language,
-            { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
-          );
-        }
-
-        function handleNumbers(str1, str2) {
-          let num1, num2;
-          num1 = parseNumberFromString(str1);
-          num2 = parseNumberFromString(str2);
-
-          if (!isNaN(num1) && !isNaN(num2)) {
-            return num1 - num2;
-          } else {
-            return strLocaleCompare(str1, str2);
-          }
-        }
-
         if (a.includes(`${fillValue}#`)) {
           return 1;
         } else if (b.includes(`${fillValue}#`)) {

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -65,11 +65,13 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
     // Doesn't infer dates with delimiter "."; as could capture semantic version numbers.
     const dmyRegex = /^(\d\d?)[/-](\d\d?)[/-]((\d\d)?\d\d)/;
     const ymdRegex = /^(\d\d\d\d)[/-](\d\d?)[/-](\d\d?)/;
+    const numericRegex = /^[+-]?(?:\d*[.,])?\d+$/;
     const inferableClasses = {
       runtime: { regexp: runtimeRegex, class: "runtime-sort", count: 0 },
       filesize: { regexp: fileSizeRegex, class: "file-size-sort", count: 0 },
       dmyDates: { regexp: dmyRegex, class: "dates-dmy-sort", count: 0 },
       ymdDates: { regexp: ymdRegex, class: "dates-ymd-sort", count: 0 },
+      numericRegex: {regexp: numericRegex, class: "numeric-sort",count:0}
     };
     let classNameAdded = false;
     let regexNotFoundCount = 0;
@@ -325,12 +327,15 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
 
       const isPunctSort = th.classList.contains("punct-sort");
       const isAlphaSort = th.classList.contains("alpha-sort");
+      const isNumericSort = th.classList.contains("numeric-sort");
       function sortAscending(a, b) {
         if (a.includes(`${fillValue}#`)) {
           return 1;
         } else if (b.includes(`${fillValue}#`)) {
           return -1;
-        } else {
+        } else if (isNumericSort) {
+          return Number(a.substring(0, a.indexOf("#"))) - Number(b.substring(0, b.indexOf("#")))
+        } else{
           return a.localeCompare(
             b,
             navigator.languages[0] || navigator.language,

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -65,7 +65,7 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
     // Doesn't infer dates with delimiter "."; as could capture semantic version numbers.
     const dmyRegex = /^(\d\d?)[/-](\d\d?)[/-]((\d\d)?\d\d)/;
     const ymdRegex = /^(\d\d\d\d)[/-](\d\d?)[/-](\d\d?)/;
-    const numericRegex = /^[+-]?(?:\d*[.,])?\d+$/;
+    const numericRegex = /^(?:\(\d+(?:\.\d+)?\)|-?\d+(?:\.\d+)?)$/;
     const inferableClasses = {
       runtime: { regexp: runtimeRegex, class: "runtime-sort", count: 0 },
       filesize: { regexp: fileSizeRegex, class: "file-size-sort", count: 0 },
@@ -329,12 +329,40 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       const isAlphaSort = th.classList.contains("alpha-sort");
       const isNumericSort = th.classList.contains("numeric-sort");
       function sortAscending(a, b) {
+        function handleNumbers(str1, str2) {
+          let num1, num2;
+          str1 = str1.slice(0, str1.indexOf("#"));
+          str2 = str2.slice(0, str2.indexOf("#"));
+
+          if (str1.match(/^\((\d+(?:\.\d+)?)\)$/)) {
+            num1 = -1 * Number(str1.slice(1, -1));
+          } else { 
+            num1 = Number(str1);
+          }
+
+          if (str2.match(/^\((\d+(?:\.\d+)?)\)$/)) {
+            num2 = -1 * Number(str2.slice(1, -1));
+          } else {
+            num2 = Number(str2);
+          }
+
+          if (!isNaN(num1) && !isNaN(num2)) {
+            return num1 - num2;
+          } else {
+            return str1.localeCompare(
+              str2,
+              navigator.languages[0] || navigator.language,
+              { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
+            );
+          }          
+        }
+
         if (a.includes(`${fillValue}#`)) {
           return 1;
         } else if (b.includes(`${fillValue}#`)) {
           return -1;
         } else if (isNumericSort) {
-          return Number(a.substring(0, a.indexOf("#"))) - Number(b.substring(0, b.indexOf("#")))
+          return handleNumbers(a, b);
         } else{
           return a.localeCompare(
             b,

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -329,32 +329,35 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       const isAlphaSort = th.classList.contains("alpha-sort");
       const isNumericSort = th.classList.contains("numeric-sort");
       function sortAscending(a, b) {
+        function parseNumberFromString(str) {
+          let num;
+          str = str.slice(0, str.indexOf("#"));
+          if (str.match(/^\((\d+(?:\.\d+)?)\)$/)) {
+            num = -1 * Number(str.slice(1, -1));
+          } else {
+            num = Number(str);
+          }
+          return num;
+        }
+
+        function strLocaleCompare(str1, str2) {
+          return str1.localeCompare(
+            str2,
+            navigator.languages[0] || navigator.language,
+            { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
+          );
+        }
+
         function handleNumbers(str1, str2) {
           let num1, num2;
-          str1 = str1.slice(0, str1.indexOf("#"));
-          str2 = str2.slice(0, str2.indexOf("#"));
-
-          if (str1.match(/^\((\d+(?:\.\d+)?)\)$/)) {
-            num1 = -1 * Number(str1.slice(1, -1));
-          } else { 
-            num1 = Number(str1);
-          }
-
-          if (str2.match(/^\((\d+(?:\.\d+)?)\)$/)) {
-            num2 = -1 * Number(str2.slice(1, -1));
-          } else {
-            num2 = Number(str2);
-          }
+          num1 = parseNumberFromString(str1);
+          num2 = parseNumberFromString(str2);
 
           if (!isNaN(num1) && !isNaN(num2)) {
             return num1 - num2;
           } else {
-            return str1.localeCompare(
-              str2,
-              navigator.languages[0] || navigator.language,
-              { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
-            );
-          }          
+            return strLocaleCompare(str1, str2);
+          }
         }
 
         if (a.includes(`${fillValue}#`)) {
@@ -363,12 +366,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
           return -1;
         } else if (isNumericSort) {
           return handleNumbers(a, b);
-        } else{
-          return a.localeCompare(
-            b,
-            navigator.languages[0] || navigator.language,
-            { numeric: !isAlphaSort, ignorePunctuation: !isPunctSort }
-          );
+        } else {
+          return strLocaleCompare(a, b);
         }
       }
 

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -433,3 +433,43 @@ test("Sort all combination of negative and positive integers and decimal numbers
     col0: ["-6","-3","-2.3","1","1.05","5","14"],
   });
 });
+
+test("Sort all combination of negative and positive integers and decimal numbers", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["1.05", "-2.3", "-3", "1", "-6", "", "14"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["-6","-3","-2.3","1","1.05","14",""],
+  });
+});
+
+
+test("Sort all negative numbers with parenthesis as well", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["1.05", "-2.3", "-3", "1", "-6", "(1.4)", "14"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["-6","-3","-2.3","(1.4)","1","1.05","14"],
+  });
+});
+
+test("Sort all combination of negative and positive integers and decimal numbers and even alphabetical random", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["1.05", "-2.3", "-3", "1", "-6", "","(0.5)","1a","b","(c)","{1}"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["{1}","-6","-3","-2.3","(0.5)","1","1.05","1a","b","(c)",""],
+  });
+});

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -408,47 +408,7 @@ test("Sort decimal numbers", () => {
   });
 });
 
-test("Sort combination of negative and positive numbers", () => {
-  expect(
-    createTestTable(
-      {
-        col0: ["1", "-2", "-3", "4", "-6", "5", "14"],
-      },
-      { classTags: "numeric-sort" }
-    )
-  ).toStrictEqual({
-    col0: ["-6","-3","-2","1","4","5","14"],
-  });
-});
-
-test("Sort all combination of negative and positive integers and decimal numbers", () => {
-  expect(
-    createTestTable(
-      {
-        col0: ["1.05", "-2.3", "-3", "1", "-6", "5", "14"],
-      },
-      { classTags: "numeric-sort" }
-    )
-  ).toStrictEqual({
-    col0: ["-6","-3","-2.3","1","1.05","5","14"],
-  });
-});
-
-test("Sort all combination of negative and positive integers and decimal numbers", () => {
-  expect(
-    createTestTable(
-      {
-        col0: ["1.05", "-2.3", "-3", "1", "-6", "", "14"],
-      },
-      { classTags: "numeric-sort" }
-    )
-  ).toStrictEqual({
-    col0: ["-6","-3","-2.3","1","1.05","14",""],
-  });
-});
-
-
-test("Sort all negative numbers with parenthesis as well", () => {
+test("Sort all combination positive, negative numbers with parenthesis as well", () => {
   expect(
     createTestTable(
       {
@@ -470,6 +430,6 @@ test("Sort all combination of negative and positive integers and decimal numbers
       { classTags: "numeric-sort" }
     )
   ).toStrictEqual({
-    col0: ["{1}","-6","-3","-2.3","(0.5)","1","1.05","1a","b","(c)",""],
+    col0: ["-6","-3","-2.3","(0.5)","1","1.05","{1}","1a","b","(c)",""],
   });
 });

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -394,3 +394,42 @@ test("dates-ymd-sort: ISO 8601 style yyyy/mm/dd; delim . or / or -", () => {
     col0: ["2023-03-9", "2023/4/6", "2023/4/32", "2023/09/6", "2023.12.16"],
   });
 });
+
+test("Sort decimal numbers", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["0.1", "0.2", "0.3", "0.11", "0.13", "0.13", "0.14"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["0.1", "0.11", "0.13", "0.13", "0.14", "0.2", "0.3"],
+  });
+});
+
+test("Sort combination of negative and positive numbers", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["1", "-2", "-3", "4", "-6", "5", "14"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["-6","-3","-2","1","4","5","14"],
+  });
+});
+
+test("Sort all combination of negative and positive integers and decimal numbers", () => {
+  expect(
+    createTestTable(
+      {
+        col0: ["1.05", "-2.3", "-3", "1", "-6", "5", "14"],
+      },
+      { classTags: "numeric-sort" }
+    )
+  ).toStrictEqual({
+    col0: ["-6","-3","-2.3","1","1.05","5","14"],
+  });
+});


### PR DESCRIPTION
Fixes issues mentioned in #63 #64

P.S. nit: used `numeric-sort` instead of `numbers-sort` ( Lemme know if you want that to be changed)