### PR TITLE
Mark processed tables

### DIFF
--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -26,7 +26,7 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
   const [getTagTable] = getHTMLTables();
   const columnIndexAndTableRow = {};
   for (let table of getTagTable) {
-    if (table.classList.contains("table-sort")) {
+    if (table.classList.contains("table-sort") && !table.classList.contains("table-processed")) {
       makeTableSortable(table);
     }
   }
@@ -113,12 +113,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
     }
   }
 
-  function makeTableSortable(sortableTable) {
-    if (sortableTable.classList.contains("table-processed")) {
-        return;
-    } else {
-        sortableTable.classList.add("table-processed");
-    }
+  function makeTableSortable(sortableTable) {  
+    sortableTable.classList.add("table-processed");
     const table = {
       bodies: getTableBodies(sortableTable),
       theads: sortableTable.querySelectorAll("thead"),

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -114,6 +114,11 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
   }
 
   function makeTableSortable(sortableTable) {
+    if (sortableTable.classList.contains("table-processed")) {
+        return;
+    } else {
+        sortableTable.classList.add("table-processed");
+    }
     const table = {
       bodies: getTableBodies(sortableTable),
       theads: sortableTable.querySelectorAll("thead"),


### PR DESCRIPTION
Make sure each table is processed once by adding the class name "table-processed". This prevents re-processing tables and attaching repeated arrows and click events in scenarios where new tables are dynamically added to a web page/application. Now, only new tables are made sortable.