### PR TITLE
Fixed position rows & parent/child row grouping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,70 @@ Examples on using table-sort-js with frontend frameworks such as [React.js](http
 | "alpha-sort"                             | Sort alphabetically (z11,z2); default is [natural sort](https://en.wikipedia.org/wiki/Natural_sort_order) (z2,z11). |
 | "punct-sort"                             | Sort punctuation; default ignores punctuation.                                                                      |
 
+<br>
+
+## Parent-Child Row Grouping
+
+Keep related rows grouped together when sorting using `data-parent` and `data-child` attributes. This is useful for tables with nested or hierarchical data where child rows should always stay with their parent row.
+
+### Usage
+
+Add `data-parent` attribute to parent rows with a unique identifier, and `data-child` attribute to child rows with the matching parent identifier:
+
+```html
+<table class="table-sort">
+  <thead>
+    <tr>
+      <th>Order ID</th>
+      <th class="numeric-sort">Amount</th>
+      <th>Customer</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- Parent row -->
+    <tr data-parent="order-1">
+      <td>1001</td>
+      <td>$250.00</td>
+      <td>John Doe</td>
+    </tr>
+    <!-- Child rows -->
+    <tr data-child="order-1">
+      <td colspan="3">Product: Laptop Stand - Qty: 2</td>
+    </tr>
+    <tr data-child="order-1">
+      <td colspan="3">Product: USB Cable - Qty: 3</td>
+    </tr>
+
+    <!-- Another parent row -->
+    <tr data-parent="order-2">
+      <td>1002</td>
+      <td>$89.99</td>
+      <td>Jane Smith</td>
+    </tr>
+    <!-- Child row -->
+    <tr data-child="order-2">
+      <td colspan="3">Product: Wireless Mouse - Qty: 1</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### How It Works
+
+- When sorting, only parent rows are sorted
+- Child rows are automatically moved with their parent
+- Child rows maintain their relative order under each parent
+- The unique identifier can be any string (including special characters like slashes for date ranges: `2025-01-01/2025-01-31`)
+
+### Use Cases
+
+- **Order details**: Show order items under each order
+- **Expandable rows**: Keep detail rows with their summary row
+- **Nested tables**: Maintain table-in-table relationships
+- **Hierarchical data**: Parent-child relationships in any form
+
+<br>
+
 ## Development:
 
 If you wish to contribute, install instructions can be found [here.](https://kyle-wannacott.github.io/table-sort-js/docs/development.html)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "homepage": "http://LeeWannacott.github.io/table-sort-js",
   "name": "table-sort-js",
+  "main": "public/table-sort.js",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/public/table-sort.js
+++ b/public/table-sort.js
@@ -6,8 +6,8 @@ Licence: MIT License Copyright (c) 2021-2024 Lee Wannacott
 GitHub Repository: https://github.com/LeeWannacott/table-sort-js
 
 Instructions:
-	Load as script:
-	<script src="https://cdn.jsdelivr.net/npm/table-sort-js/table-sort.min.js"></script>
+  Load as script:
+  <script src="https://cdn.jsdelivr.net/npm/table-sort-js/table-sort.min.js"></script>
   Add class="table-sort" to tables you'd like to make sortable
   Click on the table headers to sort them.
 */
@@ -213,6 +213,7 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
   }
 
   function sortDates(datesFormat, table, column) {
+    console.log('Sorting dates with format:', datesFormat, table, column);
     try {
       for (let [i, tr] of table.visibleRows.entries()) {
         let columnOfTd, datesRegex;
@@ -226,6 +227,7 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
           column.spanSum,
           column.span
         ).textContent;
+        console.log('columnOfTd:', columnOfTd);
         let match = columnOfTd.match(datesRegex);
         let [years, days, months] = [0, 0, 0];
         let numberToSort = columnOfTd;
@@ -242,8 +244,8 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
           }
           numberToSort = Number(
             years +
-              String(months).padStart(2, "0") +
-              String(days).padStart(2, "0")
+            String(months).padStart(2, "0") +
+            String(days).padStart(2, "0")
           );
         }
         column.toBeSorted.push(`${numberToSort}#${i}`);
@@ -464,17 +466,53 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
   function updateTable(tableProperties) {
     const { column, table, columnIndex, hasThClass } = tableProperties;
     for (let [i, tr] of table.visibleRows.entries()) {
+      let parentHTML;
       if (hasThClass.fileSize) {
         if (table.hasClass.cellsSort) {
           tr.innerHTML = updateFilesize(i, table, tr, column, columnIndex);
         } else {
-          tr.outerHTML = updateFilesize(i, table, tr, column, columnIndex);
+          parentHTML = updateFilesize(i, table, tr, column, columnIndex);
+          tr.outerHTML = parentHTML;
         }
       } else if (!hasThClass.fileSize) {
         if (table.hasClass.cellsSort) {
           tr.innerHTML = columnIndexAndTableRow[column.toBeSorted[i]];
         } else {
-          tr.outerHTML = columnIndexAndTableRow[column.toBeSorted[i]];
+          parentHTML = columnIndexAndTableRow[column.toBeSorted[i]];
+          tr.outerHTML = parentHTML;
+        }
+      }
+
+      // Insert child rows after parent if they exist
+      if (!table.hasClass.cellsSort && parentHTML) {
+        const template = !testingTableSortJS
+          ? document.createElement("template")
+          : domDocumentWindow.createElement("template");
+        template.innerHTML = parentHTML;
+        const parentRow = template.content.firstChild;
+        const parentId = parentRow ? parentRow.getAttribute("data-parent") : null;
+
+        if (parentId && table.childRowsHTML[parentId]) {
+          // Find the newly inserted parent row in the DOM
+          const allBodyRows = table.bodies.item(0).querySelectorAll("tr");
+          let insertAfterRow = null;
+
+          // Find the row we just updated
+          for (let row of allBodyRows) {
+            if (row.getAttribute("data-parent") === parentId && !row.hasAttribute("data-child")) {
+              insertAfterRow = row;
+              break;
+            }
+          }
+
+          if (insertAfterRow) {
+            // Insert all child rows after the parent
+            for (let childHTML of table.childRowsHTML[parentId]) {
+              insertAfterRow.insertAdjacentHTML("afterend", childHTML);
+              // Update reference for next child
+              insertAfterRow = insertAfterRow.nextElementSibling;
+            }
+          }
         }
       }
     }
@@ -547,12 +585,31 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
       column.spanSum = {};
       getColSpanData(table.headers[headerIndex], column);
 
-      table.visibleRows = Array.prototype.filter.call(
+      const allRows = Array.prototype.filter.call(
         table.bodies.item(headerIndex).querySelectorAll("tr"),
         (tr) => {
-          return tr.style.display !== "none";
+          return true; // tr.style.display !== "none";
         }
       );
+
+      // Detect parent-child relationships
+      table.childRowsHTML = {};
+      table.visibleRows = [];
+      for (let tr of allRows) {
+        const childAttr = tr.getAttribute("data-child");
+        if (childAttr) {
+          // This is a child row - store its HTML
+          if (!table.childRowsHTML[childAttr]) {
+            table.childRowsHTML[childAttr] = [];
+          }
+          table.childRowsHTML[childAttr].push(tr.outerHTML);
+          // Remove the original child row from DOM
+          tr.remove();
+        } else {
+          // This is either a parent row or a regular row
+          table.visibleRows.push(tr);
+        }
+      }
 
       if (!table.hasClass.rememberSort) {
         timesClickedColumn = rememberSort(
@@ -584,6 +641,7 @@ function tableSortJs(testingTableSortJS = false, domDocumentWindow = document) {
         monthDayYear: th.classList.contains("dates-mdy-sort"),
         yearMonthDay: th.classList.contains("dates-ymd-sort"),
       };
+
       // pick mdy first to override the inferred default class which is dmy.
       if (isSortDates.monthDayYear) {
         sortDates("mdy", table, column);


### PR DESCRIPTION
Hey, thank you for the great library!

We've used it in our project but we were missing two features that I decided to **vibe-code** into the library. I'm not sure if anyone is interested in it so I didn't test it very extensively. If you see any value in those I'll be happy to improve the code and add some more tests.

Features:
- Sorting of nested tables, we've had a table with list of users per month, I've added a `parent`/`child` concept that keeps the nested rows sticked to their parent row, so the table still makes sense after sorting(without it you're getting the data completely mixed what makes no sense). 
<img width="1224" height="786" alt="image" src="https://github.com/user-attachments/assets/f31297d4-9f11-4630-b67c-e723dba0ead4" />
- Fixed position row: we wanted the `totals` row to stay at the top or bottom of the table always so we've added support for `data-position` attribute that keeps the row in the same place always.